### PR TITLE
MessageBox should not be invoked from non-main thread

### DIFF
--- a/YouTubeAPI.cpp
+++ b/YouTubeAPI.cpp
@@ -15,6 +15,8 @@
 #include <regex>
 #include <array>
 
+extern DWORD g_MainThreadId;
+
 void YouTubeAPI::AddFromJson(IAIMPPlaylist *playlist, const rapidjson::Value &d, std::shared_ptr<LoadingState> state) {
     if (!playlist || !state || !Plugin::instance()->core())
         return;
@@ -406,7 +408,12 @@ void YouTubeAPI::ResolveUrl(const std::wstring &url, const std::wstring &playlis
         return;
     }
 
-    MessageBox(Plugin::instance()->GetMainWindowHandle(), Plugin::instance()->Lang(L"YouTube.Messages\\CantResolve").c_str(), Plugin::instance()->Lang(L"YouTube.Messages\\Error").c_str(), MB_OK | MB_ICONERROR);
+	if (g_MainThreadId == GetCurrentThreadId())
+		MessageBox(
+			Plugin::instance()->GetMainWindowHandle(), 
+			Plugin::instance()->Lang(L"YouTube.Messages\\CantResolve").c_str(), 
+			Plugin::instance()->Lang(L"YouTube.Messages\\Error").c_str(), 
+			MB_OK | MB_ICONERROR);
 }
 
 std::wstring messageBox(const std::wstring &msg, bool getLastError)

--- a/YouTubeAPI.cpp
+++ b/YouTubeAPI.cpp
@@ -435,7 +435,8 @@ std::wstring messageBox(const std::wstring &msg, bool getLastError)
 		}
 	}
 
-	MessageBox(Plugin::instance()->GetMainWindowHandle(), err.c_str(), Plugin::instance()->Lang(L"YouTube.Messages\\Error").c_str(), MB_OK | MB_ICONERROR);
+	if (g_MainThreadId == GetCurrentThreadId())
+		MessageBox(Plugin::instance()->GetMainWindowHandle(), err.c_str(), Plugin::instance()->Lang(L"YouTube.Messages\\Error").c_str(), MB_OK | MB_ICONERROR);
 	return nullptr;
 }
 

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -1,15 +1,19 @@
 #include <windows.h>
 
 HINSTANCE g_hInst = 0;
+DWORD g_MainThreadId = 0;
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
-    switch (ul_reason_for_call) {
-    case DLL_PROCESS_ATTACH:
-        g_hInst = hModule;
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-    case DLL_PROCESS_DETACH:
-        break;
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) 
+{
+    switch (ul_reason_for_call) 
+	{
+		case DLL_PROCESS_ATTACH:
+			g_hInst = hModule;
+			g_MainThreadId = GetCurrentThreadId();
+		case DLL_THREAD_ATTACH:
+		case DLL_THREAD_DETACH:
+		case DLL_PROCESS_DETACH:
+			break;
     }
     return TRUE;
 }


### PR DESCRIPTION
Hello,
I have fixed an issue that causes AIMP to hang. It was happened because of MessageBox that invoked from non-main thread in case when user trying to play the file that URL is deprecated or invalid (for example, the file has been removed from youtube).